### PR TITLE
fix: fixing issue with regex only getting first @env and not all of them

### DIFF
--- a/cmd/galaxy/galaxy.go
+++ b/cmd/galaxy/galaxy.go
@@ -31,7 +31,7 @@ func configFromEnv() *galaxy.Config {
 	return &galaxy.Config{
 		DotGalaxyPath: viper.GetString("config"),
 		DryRun:        viper.GetBool("dry-run"),
-		Environments:  viper.GetString("env"),
+		Environments:  viper.GetString("environment"),
 		Namespaces:    viper.GetString("namespace"),
 		LogLevel:      viper.GetString("log-level"),
 		SkipSecrets:   viper.GetBool("skip-secrets"),

--- a/pkg/galaxy/plan.go
+++ b/pkg/galaxy/plan.go
@@ -149,7 +149,7 @@ func (p *Plan) skipFile(file string) (bool, error) {
 		return false, err
 	}
 
-	res := suffixesRe.FindStringSubmatch(file)
+	res := suffixesRe.FindAllString(file, -1)
 
 	// no suffixes are found and empty suffixes are allowed
 	if len(res) == 0 && stringSliceContains(p.env.FileSuffixes, "") {


### PR DESCRIPTION
@otaviof i noticed that when using file@env1@env2@env3, the regular expression was returning always ```[@env1 @env1]``` and not ```[@env1 @env2 @env3]```